### PR TITLE
feat: Support multi-valued DICOM tags for directory organization

### DIFF
--- a/source/java/org/rsna/ctp/stdstages/DirectoryStorageService.java
+++ b/source/java/org/rsna/ctp/stdstages/DirectoryStorageService.java
@@ -320,11 +320,18 @@ public class DirectoryStorageService extends AbstractPipelineStage implements St
 		try { 
 			// Use getElementValue instead of getElementString to get the full multi-value string
 			value = dob.getElementValue(group, "");
-			// Special handling for ART/SUB pattern in OperatorsName
-			if (value.contains("ART:") && value.contains("SUB:")) {
-				value = value.replace("ART:", "ART_")
-							.replace("SUB:", "SUB_")
-							.replace("\\", "/");
+			// Special handling for GroupName ART ProjectID\SUB SubjectID pattern
+			if (value.contains(" ART ") && value.contains("\\SUB ")) {
+				// Split on the backslash separator
+				String[] parts = value.split("\\\\");
+				if (parts.length >= 2) {
+					// First part: "GroupName ART ProjectID" -> "GroupName_ART_ProjectID"
+					String firstPart = parts[0].trim().replace(" ", "_");
+					// Second part: "SUB SubjectID" -> "SubjectID" (remove SUB prefix)
+					String secondPart = parts[1].trim().replace("SUB ", "");
+					
+					value = firstPart + "/" + secondPart;
+				}
 			}
 			// General handling for other multi-valued fields
 			else {

--- a/source/java/org/rsna/ctp/stdstages/DirectoryStorageService.java
+++ b/source/java/org/rsna/ctp/stdstages/DirectoryStorageService.java
@@ -317,7 +317,20 @@ public class DirectoryStorageService extends AbstractPipelineStage implements St
 
 	private String getElementValue(DicomObject dob, String group) {
 		String value = "";
-		try { value = dob.getElementString(group); }
+		try { 
+			// Use getElementValue instead of getElementString to get the full multi-value string
+			value = dob.getElementValue(group, "");
+			// Special handling for ART/SUB pattern in OperatorsName
+			if (value.contains("ART:") && value.contains("SUB:")) {
+				value = value.replace("ART:", "ART_")
+							.replace("SUB:", "SUB_")
+							.replace("\\", "/");
+			}
+			// General handling for other multi-valued fields
+			else {
+				value = value.replace(":", "_").replace("\\", "_");
+			}
+		}
 		catch (Exception ex) { logger.debug("......exception processing: "+group); }
 		return value;
 	}


### PR DESCRIPTION
**Objective**
Fix DICOM multi-valued field handling in CTP DirectoryStorageService to access all values instead of just the first one.
**Problem**
If a field contains multiple attributes (such as Operator’s field, (0008,1070)), they end up being saved in the DICOM header as a single string separated by \, which is not handled well by the current instance of CTP.
**Requirements**
Must work with current CTP instance with minimal changes to code to avoid conflicts.
**Solution**
- Changed `getElementString()` to `getElementValue()` to get the full multi-valued string
- Replace `\` with `_` in general case
- Replace `\` with `/` for ART/SUB pattern to create subdirectories
- Replace `:` with `_` for cross-platform compatibility and better visibility
- Keep existing behavior for all other fields

**Result**
If field contains multiple elements, separated by `\`, they get used with separator `_`. For the special case of `ART:123\SUB:ABC`, it becomes `ART_testStudy/SUB_testSubject/` instead of just `ARTtestStudy/`. 